### PR TITLE
Raise Import Error on urlparse so WhatWaf can run on python 3

### DIFF
--- a/content/__init__.py
+++ b/content/__init__.py
@@ -4,7 +4,11 @@ import json
 import importlib
 import random
 import threading
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    # python 2.x doesn't have a ModuleNotFoundError so we'll just catch the exception I guess
+    import urllib.parse as urlparse
 try:
     import queue
 except ImportError:

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -8,7 +8,7 @@ import string
 import platform
 try:
     import urlparse
-except Exception:
+except ImportError:
     # python 2.x doesn't have a ModuleNotFoundError so we'll just catch the exception I guess
     import urllib.parse as urlparse
 


### PR DESCRIPTION
When I'm trying WhatWaf with Python 3.6 I got this error

```
Traceback (most recent call last):
  File "whatwaf.py", line 3, in <module>
    from whatwaf.main import main
  File "/Users/aldo/.whatwaf/.install/etc/whatwaf/main.py", line 8, in <module>
    from content import (
  File "/Users/aldo/.whatwaf/.install/etc/content/__init__.py", line 7, in <module>
    import urlparse
ModuleNotFoundError: No module named 'urlparse'
```

Then I use import error and WhatWaf can run smoothly