### PR TITLE
Fix raw_input NameError with py3

### DIFF
--- a/lib/miner/__init__.py
+++ b/lib/miner/__init__.py
@@ -20,9 +20,9 @@ import lib.firewall_found
 
 
 try:
-    raw_input
-except:
     input = raw_input
+except NameError:
+    pass
 
 
 class Miner(object):


### PR DESCRIPTION
Seems like using `raw_input` in the catch block again breaks WhatWaf
with Python 3 with a `NameError`.

This small change should fix that.